### PR TITLE
Kyonifer/develop

### DIFF
--- a/src/WorldWindow.js
+++ b/src/WorldWindow.js
@@ -684,7 +684,7 @@ define([
             this.worldWindowController.applyLimits();
             var globe = this.globe;
             var navigator = this.navigator;
-            var lookAtPosition = new Position(navigator.lookAtLocation.latitude, navigator.lookAtLocation.longitude, 0);
+            var lookAtPosition = navigator.lookAtLocation;
             modelview.multiplyByLookAtModelview(lookAtPosition, navigator.range, navigator.heading, navigator.tilt, navigator.roll, globe);
 
             if (projection) {

--- a/src/navigate/LookAtNavigator.js
+++ b/src/navigate/LookAtNavigator.js
@@ -18,10 +18,10 @@
  * @exports LookAtNavigator
  */
 define([
-        '../geom/Location',
+        '../geom/Position',
         '../navigate/Navigator',
     ],
-    function (Location,
+    function (Position,
               Navigator) {
         "use strict";
 
@@ -38,9 +38,9 @@ define([
 
             /**
              * The geographic location at the center of the viewport.
-             * @type {Location}
+             * @type {Position}
              */
-            this.lookAtLocation = new Location(30, -110);
+            this.lookAtLocation = new Position(30, -110, 0);
 
             /**
              * The distance from this navigator's eye point to its look-at location.

--- a/src/util/WWMath.js
+++ b/src/util/WWMath.js
@@ -634,7 +634,7 @@ define([
                 // Assumes a 45 degree horizontal field of view.
                 var aspectRatio = viewportHeight / viewportWidth;
 
-                return 2 * distanceToSurface / Math.sqrt(aspectRatio * aspectRatio + 5);
+                return 2 * 1.0 / Math.sqrt(aspectRatio * aspectRatio + 5);
             },
 
             /**


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Allows user to set camera altitude.
Adjusts clipping distance so that objects are still visible up close.

### Why Should This Be In Core?
Improves visualization of objects with a nonzero altitude.

### Benefits
The camera can now be set around a nonzero altitude.

### Potential Drawbacks
LookAtNavigator now requires a 3D position instead of a lat/lon pair.

### Applicable Issues